### PR TITLE
proposed changes

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/preset-env", "@babel/preset-react", "@babel/preset-typescript"]
+  "presets": ["@babel/preset-env", ["@babel/preset-react", { "runtime": "automatic" }], "@babel/preset-typescript"]
 }

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
     <img src="./tutorial/assets/webxr-first-steps.png" style="max-width:376px"/>
 </p>
 
-Welcome to **WebXR First Steps (React)**! This **2-hour** tutorial is designed to help you take your first steps into developing immersive WebXR experiences using [React Three XR](https://pmndrs.github.io/xr/docs/getting-started/introduction). Whether you’re a web developer looking to expand your skillset or a hobbyist interested in creating virtual reality (VR) applications, this tutorial will guide you through the fundamentals of building interactive 3D worlds for the web.
+Welcome to **WebXR First Steps (React)**! This **2-hour** tutorial is designed to help you take your first steps into developing immersive WebXR experiences using [React Three XR](https://pmndrs.github.io/xr/docs/). Whether you’re a web developer looking to expand your skillset or a hobbyist interested in creating virtual reality (VR) applications, this tutorial will guide you through the fundamentals of building interactive 3D worlds for the web.
 
 ## What You’ll Build
 

--- a/src/bullets.tsx
+++ b/src/bullets.tsx
@@ -7,7 +7,6 @@
 
 import { Mesh, Quaternion, Vector3 } from "three";
 
-import React from "react";
 import { create } from "zustand";
 import { generateUUID } from "three/src/math/MathUtils";
 import gsap from "gsap";
@@ -15,6 +14,7 @@ import { targets } from "./targets";
 import { useFrame } from "@react-three/fiber";
 import { useGLTF } from "@react-three/drei";
 import { useScoreStore } from "./score";
+import { useRef } from "react";
 
 const bulletSpeed = 10;
 const forwardVector = new Vector3(0, 0, -1);
@@ -69,7 +69,7 @@ type BulletProps = {
 const Bullet = ({ bulletData }: BulletProps) => {
   const { scene } = useGLTF("assets/blaster.glb");
   const bulletPrototype = scene.getObjectByName("bullet")! as Mesh;
-  const ref = React.useRef<Mesh>(null);
+  const ref = useRef<Mesh>(null);
   useFrame(() => {
     const now = performance.now();
     const bulletObject = ref.current!;

--- a/src/gun.tsx
+++ b/src/gun.tsx
@@ -11,8 +11,7 @@ import {
   useXRControllerButtonEvent,
   useXRInputSourceStateContext,
 } from "@react-three/xr";
-
-import React from "react";
+import { useRef } from "react";
 import { useBulletStore } from "./bullets";
 
 export const Gun = () => {
@@ -20,7 +19,7 @@ export const Gun = () => {
   const gamepad = state.inputSource.gamepad;
   const { scene } = useGLTF("assets/blaster.glb");
   const bulletPrototype = scene.getObjectByName("bullet")!;
-  const soundRef = React.useRef<PAudio>(null);
+  const soundRef = useRef<PAudio>(null);
   useXRControllerButtonEvent(state, "xr-standard-trigger", (state) => {
     if (state === "pressed") {
       useBulletStore

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,13 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { Canvas, addEffect, useFrame } from "@react-three/fiber";
+import { Canvas, useFrame } from "@react-three/fiber";
 import { Environment, Gltf, PerspectiveCamera } from "@react-three/drei";
 import { XR, createXRStore } from "@react-three/xr";
 
 import { Bullets } from "./bullets";
 import { Gun } from "./gun";
-import React from "react";
 import ReactDOM from "react-dom/client";
 import { Score } from "./score";
 import { Target } from "./targets";

--- a/src/score.tsx
+++ b/src/score.tsx
@@ -6,9 +6,9 @@
  */
 
 import { PositionalAudio, Text } from "@react-three/drei";
+import { useRef, useEffect } from "react";
 
 import { PositionalAudio as PAudio } from "three";
-import React from "react";
 import { create } from "zustand";
 
 type ScoreStore = {
@@ -26,9 +26,9 @@ export const Score = () => {
     return clampedScore.toString().padStart(4, "0");
   };
   const score = useScoreStore((state) => state.score);
-  const soundRef = React.useRef<PAudio>(null);
+  const soundRef = useRef<PAudio>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (score > 0) {
       const scoreSound = soundRef.current!;
       if (scoreSound.isPlaying) scoreSound.stop();

--- a/src/targets.tsx
+++ b/src/targets.tsx
@@ -6,7 +6,7 @@
  */
 
 import { Object3D } from "three";
-import React from "react";
+import { useMemo, useEffect } from "react";
 import { useGLTF } from "@react-three/drei";
 
 export const targets = new Set<Object3D>();
@@ -16,9 +16,9 @@ type TargetProps = {
 };
 export const Target = ({ targetIdx }: TargetProps) => {
   const { scene } = useGLTF("assets/target.glb");
-  const target = React.useMemo(() => scene.clone(), [scene]);
+  const target = useMemo(() => scene.clone(), [scene]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     target.position.set(
       Math.random() * 10 - 5,
       targetIdx * 2 + 1,

--- a/tutorial/chapter1.md
+++ b/tutorial/chapter1.md
@@ -4,11 +4,11 @@ Welcome to Chapter 1 of our WebXR tutorial! In this chapter, you’ll learn how 
 
 ## React Three Fiber Overview
 
-React is a well-known choice for building websites. React Three Fiber (R3F) extends React’s capabilities beyond 2D websites, enabling developers to create 3D scenes declaratively. Instead of HTML elements, R3F allows us to work directly with Three.js objects, streamlining 3D development in React.
+React is a well-known choice for building websites. React Three Fiber (R3F) extends React’s capabilities beyond 2D websites, enabling developers to create 3D scenes declaratively. Instead of HTML elements, R3F allows us to work directly with Three.js objects, enabling 3D development in React.
 
 ### Using React Three XR
 
-In combination with React Three XR, we can add WebXR support to make fully fledged AR or VR experiences. In this tutorial, we’ll use R3F and React Three XR to create a fully immersive VR mini-game.
+In combination with React Three XR, we can add WebXR support to make fully fledged Augmented Reality (AR) or Virtual Reality (VR) experiences (XR refers to AR, VR, and everything in between). In this tutorial, we’ll use R3F and React Three XR to create a fully immersive VR mini-game.
 
 ## Exploring the Starting Code in `index.tsx`
 
@@ -22,9 +22,25 @@ Let’s take a look at some of the essential parts of our starting code:
 
 1. **`Canvas` Component**: The `Canvas` is where our 3D scene is defined, much like the root `div` element in a standard React application.
 
-2. **`PerspectiveCamera`**: This component sets the position and field of view (fov) for the non-XR camera, providing a starting view for the scene.
+```tsx
+<Canvas style={{...}}>
+  //scene description
+</Canvas>
+```
+
+2. **`PerspectiveCamera`**: This component sets the position and field of view (fov) for the camera when not in XR, providing a starting view for the scene.
+
+```tsx
+<PerspectiveCamera makeDefault position={[0, 1.6, 2]} fov={75} />
+```
 
 3. **`Environment`**: The `Environment` component provides ambient lighting for the scene with a preset, simulating a well-lit warehouse.
+
+```tsx
+<Environment preset="warehouse" />
+```
+
+
 
 4. **Floor Mesh**: We define a basic floor mesh using a plane geometry, rotated to serve as the ground.
 
@@ -94,7 +110,7 @@ The starting code includes VR support using React Three XR. Here’s a breakdown
 
 1. **`createXRStore`**: This function sets up the `xrStore`, handling everything WebXR-related for our app. It has an `emulate` setting to specify the default positions and orientations of both controllers when using IWER emulation.
 
-2. **`XR` Component**: This component enables VR features in the scene by accessing the `xrStore`.
+2. **`XR` Component**: This component provides the `xrStore` to all components in the scene, giving them access to the current state of the XR session.
 
 3. **Enter VR Button**: We call `xrStore.enterVR()` to launch into the WebXR experience when the user clicks the “Enter VR” button outside the Canvas.
 
@@ -104,11 +120,9 @@ To start our target practice experience, let’s add a simple gun model to the r
 
 ### Creating `gun.tsx`
 
-Create a new file named `gun.tsx` in the same directory as `index.tsx` to define a basic gun model:
+Create a new file named `gun.tsx` in the same directory as `index.tsx` to define a basic gun model. The gun model uses the same concepts as before including meshes, geometries, and materials. In addition, we are using a **group**, which allows to group multiple 3D objects together.
 
 ```tsx
-import React from "react";
-
 export const Gun = () => {
   return (
     <group rotation-x={-Math.PI / 8}>

--- a/tutorial/chapter2.md
+++ b/tutorial/chapter2.md
@@ -90,8 +90,6 @@ const Bullet = ({ bulletData }: BulletProps) => {
 Now that we have a `Bullet` component, we can create `Bullets` to render all bullets in the scene. This component retrieves the array of bullets from Zustand and renders a `Bullet` component for each one.
 
 ```tsx
-import React from "react";
-
 export const Bullets = () => {
   const bullets = useBulletStore((state) => state.bullets);
   return (
@@ -117,11 +115,11 @@ We’ll start by creating a reference to the main barrel mesh. This reference al
 Replace `gun.tsx` with the following:
 
 ```tsx
-import React from "react";
+import { useRef } from "react"
 
 export const Gun = () => {
   // Reference for the barrel
-  const barrelRef = React.useRef<Mesh>(null);
+  const barrelRef = useRef<Mesh>(null);
 
   return (
     <group rotation-x={-Math.PI / 8}>
@@ -173,9 +171,12 @@ export const Gun = () => {
 };
 ```
 
+- **Controller State**: The `useXRInputSourceStateContext("controller)` hook from @react-three/xr allows to get the state of the current controller.
+- **Listen to Trigger State**: The `useXRControllerButtonEvent` hook enables us to listen to the state changes of the `"xr-standard-trigger"` button. Once the state is equal to `"pressed"`, we spawn the bullet at the world position and rotation of the barrel.
+
 ## Summary
 
-In this chapter, we added state management with Zustand to track bullets, created a `Bullets` component to render them, and updated the `Gun` component to spawn bullets when the trigger is pressed. This sets the stage for more complex interactions, like moving these bullets, which we’ll cover in the next chapter.
+In this chapter, we added state management with Zustand to track bullets, created a `Bullets` component to render them, and updated the `Gun` component to spawn bullets when the trigger is pressed. In the next chapter, we'll cover moving the spawned bullets.
 
 Here’s what our scene looks like after adding the bullet spawning feature:
 

--- a/tutorial/chapter3.md
+++ b/tutorial/chapter3.md
@@ -1,6 +1,6 @@
 # Chapter 3: Animating Bullet Objects
 
-In this chapter, we’ll make the bullets move forward in the direction the controller is pointing and disappear after a set time. This involves managing each bullet’s movement and lifespan to ensure they don’t remain in the scene indefinitely.
+In this chapter, we’ll make the bullets move forward in their spawn direction and disappear after a set time. This involves managing each bullet’s movement and lifespan to ensure they don’t remain in the scene indefinitely.
 
 ## Constants for Bullet Behavior
 
@@ -12,8 +12,8 @@ const forwardVector = new Vector3(0, 0, -1);
 const bulletTimeToLive = 2;
 ```
 
-- **`forwardVector`**: This vector points forward along the negative Z-axis, representing the default direction bullets will move.
 - **`bulletSpeed`**: Sets the speed of bullets, here set to 10 units per second.
+- **`forwardVector`**: This vector points forward along the negative Z-axis, representing the default direction bullets will move.
 - **`bulletTimeToLive`**: Defines how long each bullet stays in the scene before being removed (2 seconds in this example).
 
 ## Extending Zustand for Bullet Lifespan
@@ -62,7 +62,7 @@ export const useBulletStore = create<BulletStore>((set) => ({
 
 ## Updating Bullet Position Over Time
 
-To animate each bullet, we’ll use the `useFrame` hook from `@react-three/fiber`. The `useFrame` hook is part of the **frameloop** in React Three Fiber, which runs continuously on every frame to update the scene. By using `useFrame`, we can update the position of each bullet in real-time, making them move smoothly forward as long as they’re active.
+To animate each bullet, we’ll use the `useFrame` hook from `@react-three/fiber`. The `useFrame` hook is part of the **frameloop** in React Three Fiber, which runs continuously on every frame to update the scene. By using `useFrame`, we can update the position of each bullet in real-time, making them move smoothly forward.
 
 ### Bullet Component
 
@@ -70,15 +70,15 @@ In the `Bullet` component, we add `useFrame` to update each bullet’s position 
 
 ```tsx
 import { Mesh, Vector3 } from "three";
-import React from "react";
 import { useFrame } from "@react-three/fiber";
+import { useRef } from "react"
 
 type BulletProps = {
   bulletData: BulletData;
 };
 
 const Bullet = ({ bulletData }: BulletProps) => {
-  const ref = React.useRef<Mesh>(null);
+  const ref = useRef<Mesh>(null);
 
   useFrame(() => {
     const now = performance.now();
@@ -107,11 +107,11 @@ Let's break this down:
 
 - **`useFrame` Hook**: Runs each frame, updating the bullet’s position to move it forward over time.
 - **Direction Calculation**: We apply the bullet’s initial quaternion to the `forwardVector`, aligning its movement with the orientation of the gun when it was fired.
-- **Position Update**: The bullet’s position is updated along this direction at the specified `bulletSpeed`. This creates a consistent forward motion.
+- **Position Update**: The bullet’s position is updated to the sum of the initial position and the direction vector multiplied by the `bulletSpeed` and the time passed since the bullet was spawned. This creates a consistent forward motion.
 
 ## Summary
 
-In this chapter, you’ve enhanced your WebXR scene by animating the bullets. Now, when fired, the bullets travel in the direction the controller is pointing and disappear after a set time. This addition introduces dynamic motion to your scene and maintains performance by removing bullets after they’re no longer needed.
+In this chapter, we've animated the bullets. Now, when fired, the bullets travel in the direction the controller is pointing and disappear after a set time. This addition introduces dynamic motion to your scene and maintains performance by removing bullets after they’re no longer needed.
 
 Here’s what our scene looks like with the bullet animation feature:
 

--- a/tutorial/chapter4.md
+++ b/tutorial/chapter4.md
@@ -20,8 +20,6 @@ import { Gltf } from "@react-three/drei";
 
 The space station provides an immersive backdrop for your WebXR experience, setting the scene for the interaction to come.
 
-![Space Station Model](./assets/space-station.png)
-
 ## 2. Adding the Blaster Model to the Gun Component
 
 Now let’s replace the basic geometry of the gun with a 3D blaster model.
@@ -38,7 +36,6 @@ import {
   useXRControllerButtonEvent,
   useXRInputSourceStateContext,
 } from "@react-three/xr";
-import React from "react";
 import { useBulletStore } from "./bullets";
 import { useGLTF } from "@react-three/drei";
 
@@ -83,6 +80,7 @@ We’ll get the `bulletPrototype` in `Bullet`, allowing each bullet to inherit i
 
 ```tsx
 import { useGLTF } from "@react-three/drei";
+import { useRef } from "react"
 
 type BulletProps = {
   bulletData: BulletData;
@@ -91,7 +89,7 @@ type BulletProps = {
 const Bullet = ({ bulletData }: BulletProps) => {
   const { scene } = useGLTF("assets/blaster.glb");
   const bulletPrototype = scene.getObjectByName("bullet")! as Mesh;
-  const ref = React.useRef<Mesh>(null);
+  const ref = useRef<Mesh>(null);
   useFrame(() => {
     const now = performance.now();
     const bulletObject = ref.current!;
@@ -111,7 +109,7 @@ const Bullet = ({ bulletData }: BulletProps) => {
       ref={ref}
       geometry={bulletPrototype.geometry}
       material={bulletPrototype.material}
-      quaternion={bulletData.initQuaternion.toArray()}
+      quaternion={bulletData.initQuaternion}
     ></mesh>
   );
 };
@@ -138,11 +136,11 @@ export const targets = new Set<Object3D>();
 
 ### Rendering the Targets
 
-With the `TargetStore` in place, we’ll load the target model and position three targets at random points. Each target is cloned, added to the store, and rendered with random initial positions.
+With the `TargetStore` in place, we’ll load the target model and position three targets at random points. Each target is cloned, added to the store, and rendered with random positions.
 
 ```tsx
-import React from "react";
 import { useGLTF } from "@react-three/drei";
+import { useEffect, useMemo } from "react";
 
 type TargetProps = {
   targetIdx: number;
@@ -150,9 +148,9 @@ type TargetProps = {
 
 export const Target = ({ targetIdx }: TargetProps) => {
   const { scene } = useGLTF("assets/target.glb");
-  const target = scene.clone();
+  const target = useMemo(() => scene.clone(), [])
 
-  React.useEffect(() => {
+  useEffect(() => {
     target.position.set(
       Math.random() * 10 - 5,
       targetIdx * 2 + 1,

--- a/tutorial/chapter5.md
+++ b/tutorial/chapter5.md
@@ -1,6 +1,6 @@
 # Chapter 5: Making It a Game
 
-In this chapter, we’ll add a proximity-based hit test for the targets and implement a scoreboard to track the player’s score. These additions make the scene more interactive and engaging, transforming it into a simple game.
+In this chapter, we’ll add a proximity-based hit test for the targets and implement a scoreboard to track the player’s score. These additions make the scene more interactive and engaging, turning our app into a simple game.
 
 ## 1. Setting Up the Scoreboard
 
@@ -29,7 +29,6 @@ export const useScoreStore = create<ScoreStore>((set) => ({
 Next, we’ll render the score using the `Text` component from `@react-three/drei`. This component provides high-quality, customizable text rendering, ideal for showing the score on a monitor in the scene.
 
 ```tsx
-import React from "react";
 import { Text } from "@react-three/drei";
 import { useScoreStore } from "./score";
 
@@ -68,11 +67,11 @@ To determine if a bullet hits a target, we’ll use a proximity-based hit test. 
 
 ### Updating `bullet.tsx`
 
-In `bullet.tsx`, we’ll import the target and score stores and implement the hit detection logic inside the `Bullet` component.
+In `bullet.tsx`, we’ll import the the score store and targets and implement the hit detection logic inside the `Bullet` component.
 
 ```tsx
 import { useScoreStore } from "./score";
-import { useTargetStore } from "./targets";
+import { targets } from "./targets";
 
 const Bullet = ({ bulletPrototype, bulletData }: BulletProps) => {
   // ... existing code
@@ -111,7 +110,7 @@ This hit test works effectively for our game since the targets are round and fac
 
 ## Summary
 
-In this chapter, you’ve turned your WebXR experience into a simple game by adding a hit test and a scoreboard. The proximity-based hit test registers hits when bullets are near targets, while the scoreboard tracks the player’s score and updates in real time, adding an engaging, interactive element to the scene.
+In this chapter, you’ve turned your WebXR experience into a simple game by adding a hit test and a scoreboard. The proximity-based hit test registers hits when bullets are near targets, while the scoreboard tracks the player’s score and updates in real time, making our game playable.
 
 Here’s what the game looks like with hit detection and scoring:
 

--- a/tutorial/chapter6.md
+++ b/tutorial/chapter6.md
@@ -13,10 +13,11 @@ In `gun.tsx`, we’ll add a sound for when the player fires the blaster.
 ```tsx
 import { PositionalAudio as PAudio } from "three";
 import { PositionalAudio } from "@react-three/drei";
+import { useRef } from "react"
 
 export const Gun = () => {
   // ... existing code
-  const soundRef = React.useRef<PAudio>(null);
+  const soundRef = useRef<PAudio>(null);
 
   useXRControllerButtonEvent(state, "xr-standard-trigger", (state) => {
     if (state === "pressed") {
@@ -46,12 +47,13 @@ In `score.tsx`, we play a sound whenever the score changes.
 ```tsx
 import { PositionalAudio } from "@react-three/drei";
 import { PositionalAudio as PAudio } from "three";
+import { useEffect, useRef } from "react";
 
 export const Score = () => {
   const score = useScoreStore((state) => state.score);
-  const soundRef = React.useRef<PAudio>(null);
+  const soundRef = useRef<PAudio>(null);
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (score > 0) {
       const scoreSound = soundRef.current!;
       if (scoreSound.isPlaying) scoreSound.stop();
@@ -78,6 +80,7 @@ We’ll add haptic feedback to give tactile responses when shooting. This vibrat
 
 ```tsx
 export const Gun = () => {
+  // ... existing code
   const gamepad = state.inputSource.gamepad;
   useXRControllerButtonEvent(state, "xr-standard-trigger", (state) => {
     if (state === "pressed") {
@@ -90,7 +93,6 @@ export const Gun = () => {
 ```
 
 - **Haptic Feedback**: The `pulse` method triggers a vibration at 60% intensity for 100 milliseconds.
-- **Fallback**: A try-catch isn’t necessary here as the `?` safely handles missing haptic actuators.
 
 ## 3. Adding Visual Feedback with GSAP
 
@@ -152,16 +154,19 @@ Congratulations! You’ve completed the WebXR First Steps tutorial, building a f
 
 ![Shrinking Targets](./assets/chapter6.gif)
 
+[View full changes made in this chapter](https://github.com/meta-quest/webxr-first-steps-react/compare/chapter5...chapter6)
+
 ## What’s Next?
 
 Though the tutorial is complete, your journey with WebXR has only just begun! Here are some ways you can continue to expand your game:
 
+- **Augmented Reality Mode**: Experience your game in AR by allowing adding an `enterAR` button.
 - **Dual Wielding**: Add a blaster to the other controller for a dual-wielding experience.
+- **Larger Map**: Use a larger map, spawn targets everywhere, and add [teleportation](https://pmndrs.github.io/xr/docs/tutorials/teleport).
 - **Timed Challenge**: Introduce a timer to create a race-against-the-clock gameplay style.
 - **Moving Targets**: Add difficulty by having targets move around the scene.
 - **Exploding Targets**: Make the targets explode with visual effects when hit.
-- **And More!**: Experiment with new features to personalize and expand your game.
+
+Beyond expanding your game, you can also check out the [react-three/xr docs](https://pmndrs.github.io/xr/docs/) for more tutorials and insights into what is possible in WebXR using react.
 
 Thank you for following along! Enjoy building even more with WebXR. Happy coding!
-
-[View full changes made in this chapter](https://github.com/meta-quest/webxr-first-steps-react/compare/chapter5...chapter6)


### PR DESCRIPTION
I really like the tutorials! Here's a list of the types of changes I am proposing in this PR.

Changes:

- Small wording changes (very subjective)
- Code fixes (e.g. adding useMemo in the tutorial and fixing the import for `targets`)
- Remove `import React from "react"` and usage from `React.useEffect`, ... to `useEffect` while (re-)adding the necessary imports 
- Add more options to "what's next"

Let me know if you disagree with any of these changes.
If the removal of `import React from "react"` looks good, I can apply it to all the chapter branches because it requires to exchange `"@babel/preset-react"` with `["@babel/preset-react", { "runtime": "automatic" }]` in `.babelrc`.